### PR TITLE
Make readme not so misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Depending on configuration, those objects may themselves be stored as BSON sub-d
 or in the native Julia serialization format (default).
 It is fast and efficient to load just single objects out of a larger file that contains many objects.
 
-The metadata (always stored in BSON) includes the Julia version and the versions of all packagers installed.
-This means in the worst case you can installed everything again and replicate your system.
-(Extreme worst case senario, using a BSON reader from anyther programming language).
+The metadata (always stored in BSON) includes the Julia version and the versions of all packages installed.
+This means in the worst case you can install everything again and replicate your system.
+(Extreme worst case scenario, using a BSON reader from another programming language).
 
-Note: that if the amount of data you have to store is very small, relative to the metadata about your enviroment.
+Note: If the amount of data you have to store is very small, relative to the metadata about your environment, then it is a pretty suboptimal format.
 Then is is a pretty suboptimal format.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/invenia/JLSO.jl?svg=true)](https://ci.appveyor.com/project/invenia/JLSO-jl)
 [![Codecov](https://codecov.io/gh/invenia/JLSO.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/JLSO.jl)
 
-JLSO wraps other formats (currently [BSON](https://github.com/MikeInnes/BSON.jl)),
-while storing key metadata such as the version of julia and all involved packages
-that were used in creating the file.
+JLSO is a storage container for serialized Julia objects.
+At the top-level it is a BSON file,
+where it stores metadata about the system it was created on as well as a collection of objects (the actual data).
+
+Depending on configuration, those objects may themselves be stored as BSON sub-documents,
+or in the native Julia serialization format (default).
+It is fast and efficient to load just single objects out of a larger file that contains many objects.
+
+The metadata (always stored in BSON) includes the Julia version and the versions of all packagers installed.
+This means in the worst case you can installed everything again and replicate your system.
+(Extreme worst case senario, using a BSON reader from anyther programming language).
+
+Note: that if the amount of data you have to store is very small, relative to the metadata about your enviroment.
+Then is is a pretty suboptimal format.


### PR DESCRIPTION
This is not a great readme still, but at least it doesn't say anything misleading.
Like this currently implies it just wraps BSON.

When really JLSO is a mullet:
 BSON (work) at the front  and by default Julia Serializer (party) at the back.