### PR TITLE
Release v1.1.0. But First: Are we happy with the version numbers?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,8 @@
 name = "JLSO"
 uuid = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 license = "MIT"
-authors = ["Rory Finnegan <rory.finnegan@invenia.ca>"]
+authors = ["Invenia Technical Computing Corperation"]
+version = "1.1.0"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"


### PR DESCRIPTION
This release can read .jlso files v1.0 and v2.0 
and can only write  .jlso files v2.0

JLSO.jl v1.0.0 can only read and write v1.0 formats

This is thus backwards compatible with JLSO v1.0.0
but not forwards compatible. This is correct SemVer behavour AFAICT.
Julia v1.1 can run all julia 1.0 programs, but julia v1.0 can not run v1.0 programs.

Are we happy with this world?
We could change the file version to be `v1.1` so it matchs the JLSO.jl version that creates it.
or we can let it them swing freely.

AFAIK there is no standard like SemVer for file format versions.
Julia's serialization stdlib just uses an integer.
https://github.com/JuliaLang/julia/blob/7a75753ab84bb401bbcb120faa9f96d6d3042f7f/stdlib/Serialization/src/Serialization.jl#L78
