### PR TITLE
Activate pkg envs from JLSOFiles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,10 +19,14 @@ julia = "0.7, 1.0"
 [extras]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [targets]
-test = ["AxisArrays", "DataFrames", "Distributions", "Suppressor", "Test", "TimeZones"]
+test = ["AxisArrays", "DataFrames", "Dates", "Distributed", "Distributions", "InteractiveUtils", "Random", "Suppressor", "Test", "TimeZones"]

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -97,9 +97,21 @@ function _upgrade_env(pkgs::Dict)
         mktempdir() do tmp
             Pkg.activate(tmp)
 
-            # We construct an array of PackageSpecs to avoid ordering problems with adding
-            # each package individually
-            Pkg.add([Pkg.PackageSpec(; name=key, version=value) for (key, value) in pkgs])
+            # We construct an array of PackageSpecs to avoid ordering problems with
+            # adding each package individually
+            try
+                Pkg.add([
+                    Pkg.PackageSpec(; name=key, version=value) for (key, value) in pkgs
+                ])
+            catch e
+                # Warn about failure and fallback to simply trying to install the pacakges
+                # without version constraints.
+                warn(LOGGER) do
+                    "Failed to construct an environment with the provide package version " *
+                    "($pkgs): $e.\n Falling back to simply adding the packages."
+                end
+                Pkg.add([Pkg.PackageSpec(; name=key) for (key, value) in pkgs])
+            end
 
             return _env()
         end

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -53,14 +53,14 @@ function _image()
     return _CACHE[:IMAGE]
 end
 
-function Pkg.activate(jlso::JLSOFile, path; kwargs...)
+function Pkg.activate(jlso::JLSOFile, path=tempdir(); kwargs...)
     ispath(path) || mkpath(path)
     open(io -> Pkg.TOML.print(io, jlso.project), joinpath(path, "Project.toml"), "w")
     open(io -> Pkg.TOML.print(io, jlso.manifest), joinpath(path, "Manifest.toml"), "w")
     Pkg.activate(path; kwargs...)
 end
 
-function Pkg.activate(f::Function, jlso::JLSOFile, path; kwargs...)
+function Pkg.activate(f::Function, jlso::JLSOFile, path=tempdir(); kwargs...)
     curr_env = dirname(Base.active_project())
     try
         Pkg.activate(jlso, path; kwargs...)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -52,3 +52,20 @@ function _image()
 
     return _CACHE[:IMAGE]
 end
+
+function Pkg.activate(jlso::JLSOFile, path; kwargs...)
+    ispath(path) || mkpath(path)
+    open(io -> Pkg.TOML.print(io, jlso.project), joinpath(path, "Project.toml"), "w")
+    open(io -> Pkg.TOML.print(io, jlso.manifest), joinpath(path, "Manifest.toml"), "w")
+    Pkg.activate(path; kwargs...)
+end
+
+function Pkg.activate(f::Function, jlso::JLSOFile, path; kwargs...)
+    curr_env = dirname(Base.active_project())
+    try
+        Pkg.activate(jlso, path; kwargs...)
+        f()
+    finally
+        Pkg.activate(curr_env)
+    end
+end

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -54,7 +54,7 @@ function _image()
 end
 
 function Pkg.activate(jlso::JLSOFile, path=tempdir(); kwargs...)
-    ispath(path) || mkpath(path)
+    mkpath(path)
     open(io -> Pkg.TOML.print(io, jlso.project), joinpath(path, "Project.toml"), "w")
     open(io -> Pkg.TOML.print(io, jlso.manifest), joinpath(path, "Manifest.toml"), "w")
     Pkg.activate(path; kwargs...)

--- a/test/JLSOFile.jl
+++ b/test/JLSOFile.jl
@@ -40,3 +40,18 @@ end
     )
     @test sprint(show, jlso) == sprint(print, jlso)
 end
+
+@testset "activate" begin
+    jlso = JLSOFile(datas[:String])
+    mktempdir() do d
+        Pkg.activate(jlso, d) do
+            @show Base.active_project()
+        end
+
+        @test ispath(joinpath(d, "Project.toml"))
+        @test ispath(joinpath(d, "Manifest.toml"))
+
+        @test Pkg.TOML.parsefile(joinpath(d, "Project.toml")) == jlso.project
+        @test Pkg.TOML.parsefile(joinpath(d, "Manifest.toml")) == jlso.manifest
+    end
+end

--- a/test/backwards_compat.jl
+++ b/test/backwards_compat.jl
@@ -25,6 +25,29 @@
             @test isempty(new_d["metadata"]["manifest"])
             @test isempty(new_d["objects"])
         end
+
+        @testset "Invalid VersionNumber" begin
+            d = Dict(
+                "metadata" => Dict(
+                    "version" => v"1.0", "format" => :bson,
+                    # We don't intend to go back an make a 0.3.14 release at any point.
+                    "pkgs" => merge(pkgs, Dict("JLSO" => v"0.3.14")),
+                )
+            )
+
+            new_d = @suppress_out upgrade_jlso(d)
+            @test !isempty(new_d["metadata"]["project"])
+            @test !isempty(new_d["metadata"]["manifest"])
+
+            # Test that the project.toml has the JLSO dep, but not a specific version
+            # (fallback when package versions don't exist in the registry)
+            _project = Pkg.TOML.parse(new_d["metadata"]["project"])
+            @test haskey(_project, "deps")
+            @test haskey(_project["deps"], "JLSO")
+            @test haskey(_project, "compat")
+            # Check that the compat section doesn't have our package version
+            @test !haskey(_project["compat"], "JLSO")
+        end
     end
 end
 

--- a/test/file_io.jl
+++ b/test/file_io.jl
@@ -40,7 +40,12 @@ end
 
         # Test failing to deserialize data because of incompatible julia versions
         # will return the raw bytes
-        result = @test_warn(LOGGER, r"MethodError*", jlso["data"])
+        result = if VERSION < v"1.2"
+            @test_warn(LOGGER, r"MethodError*", jlso["data"])
+        else
+            @test_warn(LOGGER, r"TypeError*", jlso["data"])
+        end
+
         @test result == hw_5
 
         # TODO: Test that BSON works across julia versions using external files?


### PR DESCRIPTION
- Closes #28 
- More graceful failures on failure during _upgrade_env (needed when tagging new releases)