### PR TITLE
Create directory structure of destination when upgrading

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -71,11 +71,12 @@ function upgrade(sources::Vector, destinations::Vector)
 
     if !isempty(iter)
         (src, dest), s = iterate(iter)
-
+        mkpath(dirname(dest))
         jlso = open(io -> read(io, JLSOFile), src)
         write(dest, jlso)
 
         for (src, dest) in Iterators.rest(iter, s)
+            mkpath(dirname(dest))
             upgrade(src, dest, jlso.project, jlso.manifest)
         end
     end


### PR DESCRIPTION
Tried out `upgrade` was pretty good,
except i had a whole directory structure to match.
and so creating all those folders was annoying.
(I ended up just using `; cp -r old new` to copy everything)