### PR TITLE
Use multithreaded load / save per entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "JLSO"
 uuid = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 license = "MIT"
 authors = ["Invenia Technical Computing Corperation"]
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/JLSO.jl
+++ b/src/JLSO.jl
@@ -42,6 +42,14 @@ using Memento
 using Pkg: Pkg
 using Pkg.Types: semver_spec
 
+@static if VERSION < v"1.3.0"
+    macro spawn(ex)
+        esc(ex)
+    end
+else
+    using Base.Threads: @spawn 
+end
+
 # We need to import these cause of a deprecation on object index via strings.
 import Base: getindex, setindex!
 

--- a/src/JLSOFile.jl
+++ b/src/JLSOFile.jl
@@ -1,4 +1,4 @@
-import Base.Threads: @spawn
+using Base.Threads: @spawn
 
 struct JLSOFile
     version::VersionNumber

--- a/src/JLSOFile.jl
+++ b/src/JLSOFile.jl
@@ -1,5 +1,3 @@
-using Base.Threads: @spawn
-
 struct JLSOFile
     version::VersionNumber
     julia::VersionNumber

--- a/src/JLSOFile.jl
+++ b/src/JLSOFile.jl
@@ -1,3 +1,5 @@
+import Base.Threads: @spawn
+
 struct JLSOFile
     version::VersionNumber
     julia::VersionNumber
@@ -7,6 +9,7 @@ struct JLSOFile
     project::Dict{String, Any}
     manifest::Dict{String, Any}
     objects::Dict{Symbol, Vector{UInt8}}
+    lock::ReentrantLock
 end
 
 """
@@ -56,10 +59,11 @@ function JLSOFile(
         Pkg.TOML.parse(project_toml),
         Pkg.TOML.parse(manifest_toml),
         Dict{Symbol, Vector{UInt8}}(),
+        ReentrantLock()
     )
 
     for (key, val) in data
-        jlso[key] = val
+        @spawn jlso[key] = val
     end
 
     return jlso

--- a/src/JLSOFile.jl
+++ b/src/JLSOFile.jl
@@ -62,7 +62,7 @@ function JLSOFile(
         ReentrantLock()
     )
 
-    for (key, val) in data
+    @sync for (key, val) in data
         @spawn jlso[key] = val
     end
 

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -95,9 +95,9 @@ function load(io::IO, objects::Symbol...)
         @spawn begin
             # Note that calling getindex on the jlso triggers the deserialization of the object
             deserialized = jlso[o]
-            lock(jlso.lock)
-            result[o] = deserialized
-            unlock(jlso.lock)
+            lock(jlso.lock) do
+                result[o] = deserialized
+            end
         end
     end
 

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -1,5 +1,3 @@
-using Base.Threads: @spawn 
-
 # This is the code that handles getting the JLSO file itself on to and off of the disk
 # However, it does not describe how to serialize or deserialize the individual objects
 # that is done lazily and the code for that is in serialization.jl

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -1,4 +1,4 @@
-import Base.Threads: @spawn 
+using Base.Threads: @spawn 
 
 # This is the code that handles getting the JLSO file itself on to and off of the disk
 # However, it does not describe how to serialize or deserialize the individual objects

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -69,7 +69,7 @@ function setindex!(jlso::JLSOFile, value, name::Symbol)
     complete_compression(compressing_buffer)
     result = take!(buffer)
 
-    lock(jlso.lock)
-    jlso.objects[name] = result
-    unlock(jlso.lock)
+    lock(jlso.lock) do
+        jlso.objects[name] = result
+    end
 end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -67,6 +67,9 @@ function setindex!(jlso::JLSOFile, value, name::Symbol)
     compressing_buffer = compress(jlso.compression, buffer)
     serialize(jlso.format, compressing_buffer, value)
     complete_compression(compressing_buffer)
+    result = take!(buffer)
 
-    jlso.objects[name] = take!(buffer)
+    lock(jlso.lock)
+    jlso.objects[name] = result
+    unlock(jlso.lock)
 end

--- a/src/upgrade.jl
+++ b/src/upgrade.jl
@@ -35,6 +35,7 @@ function upgrade(src, dest, project, manifest)
         project,
         manifest,
         Dict{Symbol, Vector{UInt8}}(Symbol(k) => v for (k, v) in d["objects"]),
+        ReentrantLock()
     )
     write(dest, jlso)
 end

--- a/test/file_io.jl
+++ b/test/file_io.jl
@@ -36,6 +36,7 @@ end
                 project,
                 manifest,
                 Dict(:data => hw_5),
+                ReentrantLock()
             )
         end
 
@@ -94,6 +95,7 @@ end
                     project,
                     manifest,
                     Dict(:data => bytes),
+                    ReentrantLock()
                 )
 
                 # Test failing to deserailize data because of missing modules will
@@ -130,6 +132,7 @@ end
                     project,
                     manifest,
                     Dict(:data => bytes),
+                    ReentrantLock()
                 )
 
                 # Test failing to deserailize data because of missing modules will


### PR DESCRIPTION
Loading 10GB of data on a laptop with 4 cores goes from
```
julia> example()
 43.730908 seconds (11.57 k allocations: 9.866 GiB, 2.12% gc time)
```
to
```
julia> example()
 14.883994 seconds (11.60 k allocations: 9.866 GiB, 1.79% gc time)
```

Saving is probably even more interesting, that took 6mins, I can check if it goes to 1.5 minutes with this PR