### PR TITLE
Add support for the FileIO interface

### DIFF
--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -103,3 +103,7 @@ function load(io::IO, objects::Symbol...)
 
     return result
 end
+
+# FileIO Interface
+fileio_save(f, args...; kwargs...) = save(f.filename, args...; kwargs...)
+fileio_load(f, args...) = load(f.filename, args...)


### PR DESCRIPTION
I'll add tests for the next release of FileIO once https://github.com/JuliaIO/FileIO.jl/pull/260 is merged and tagged.

For now I've just tested this in the REPL:

```julia
julia> using JLSO, FileIO
[ Info: Precompiling FileIO [5789e2e9-d7fb-5bc7-8068-2c6fae9b9549]

julia> load("foo.jlso")
Dict{Symbol,Any} with 2 entries:
  :bar => 3
  :foo => 1
```