### PR TITLE
WIP: Autoload object deps

### DIFF
--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -118,8 +118,11 @@ end
 Load the JLSOFile from the io and deserialize the specified objects.
 If no object names are specified then all objects in the file are returned.
 """
-load(path::Union{AbstractPath, AbstractString}, args...) = open(io -> load(io, args...), path)
-function load(io::IO, objects::Symbol...)
+function load(path::Union{AbstractPath, AbstractString}, args...; kwargs...)
+    open(io -> load(io, args...; kwargs...), path)
+end
+
+function load(io::IO, objects::Symbol...; kwargs...)
     jlso = read(io, JLSOFile)
     objects = isempty(objects) ? names(jlso) : objects
     result = Dict{Symbol, Any}()
@@ -127,7 +130,7 @@ function load(io::IO, objects::Symbol...)
     @sync for o in objects
         @spawn begin
             # Note that calling getindex on the jlso triggers the deserialization of the object
-            deserialized = jlso[o]
+            deserialized = getindex(jlso, o; kwargs...)
             lock(jlso.lock) do
                 result[o] = deserialized
             end


### PR DESCRIPTION
MWE for autoloading object dependencies. I'm not sure how we want the API to work yet and it might make sense to include an example combining `Pkg.activate(f, jlso)` with this autoloading functionality and Revise.jl.

Example:
```julia
julia> using JLSO, Pkg

julia> jlso = read("test/specimens/v4_julia_serialize_none.jlso", JLSOFile)
JLSOFile([ZonedDateTime, DataFrame, Vector, DateTime, String, Matrix, Distribution]; version="4.0.0", julia="1.0.5", format=:julia_serialize, compression=:none, image="")

julia> Pkg.activate(jlso)
 Activating environment at `/var/folders/vz/zx_0gsp9291dhv049t_nx37r0000gn/T/Project.toml`

julia> jlso[:DataFrame]
[warn | JLSO]: KeyError: key DataFrames [a93c6f00-e57d-5684-b7b6-d8193f3e46c0] not found
278-element Array{UInt8,1}:
 0x37
 0x4a
 0x4c
 0x07
 0x04
 0x00
 0x00
 0x00
 0x34
 ...
 
 julia> getindex(jlso, :DataFrame; autoload=true)
[ Info: Precompiling DataFrames [a93c6f00-e57d-5684-b7b6-d8193f3e46c0]
5×4 DataFrame
│ Row │ a     │ b        │ c      │ d    │
│     │ Int64 │ Float64  │ String │ Bool │
├─────┼───────┼──────────┼────────┼──────┤
│ 1   │ 1     │ 0.867244 │ a      │ 1    │
│ 2   │ 2     │ 0.711437 │ b      │ 1    │
│ 3   │ 3     │ 0.512452 │ c      │ 0    │
│ 4   │ 4     │ 0.863122 │ d      │ 0    │
│ 5   │ 5     │ 0.907903 │ e      │ 1    │
```
 
 