### PR TITLE
Bumping minor release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "JLSO"
 uuid = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 license = "MIT"
 authors = ["Invenia Technical Computing Corperation"]
-version = "2.4.0"
+version = "2.5.0"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"


### PR DESCRIPTION
Since we're post 1.0 and we've bumped the BSON dependency, so we're tagging a new minor release.