### PR TITLE
Add some methods to make JLSOFile more Dict-like

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "JLSO"
 uuid = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 license = "MIT"
 authors = ["Invenia Technical Computing Corperation"]
-version = "2.5.0"
+version = "2.6.0"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/JLSOFile.jl
+++ b/src/JLSOFile.jl
@@ -75,8 +75,9 @@ function JLSOFile(;
     image=_image(),
     kwargs...
 )
+    data = isempty(kwargs) ? Dict{Symbol,Any}() : Dict(kwargs)
     return JLSOFile(
-        Dict(kwargs);
+        data;
         version=version,
         julia=julia,
         format=format,

--- a/src/JLSOFile.jl
+++ b/src/JLSOFile.jl
@@ -117,3 +117,18 @@ function Base.:(==)(a::JLSOFile, b::JLSOFile)
 end
 
 Base.names(jlso::JLSOFile) = collect(keys(jlso.objects))
+
+Base.keys(jlso::JLSOFile) = keys(jlso.objects)
+
+Base.haskey(jlso::JLSOFile, key) = haskey(jlso.objects, key)
+
+Base.get(jlso::JLSOFile, key, default) = haskey(jlso, key) ? jlso[key] : default
+
+Base.get!(jlso::JLSOFile, key, default) = get!(() -> default, jlso, key)
+function Base.get!(func, jlso::JLSOFile, key)
+    return if haskey(jlso, key)
+        jlso[key]
+    else
+        jlso[key] = func()
+    end
+end

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -105,7 +105,8 @@ end
 
 Creates a JLSOFile with the specified data and kwargs and writes it back to the io.
 """
-save(io::IO, data; kwargs...) = write(io, JLSOFile(data; kwargs...))
+save(io::IO, data::JLSOFile) = write(io, data)
+save(io::IO, data; kwargs...) = save(io, JLSOFile(data; kwargs...))
 save(io::IO, data::Pair...; kwargs...) = save(io, Dict(data...); kwargs...)
 function save(path::Union{AbstractPath, AbstractString}, args...; kwargs...)
     return open(io -> save(io, args...; kwargs...), path, "w")

--- a/test/JLSOFile.jl
+++ b/test/JLSOFile.jl
@@ -22,6 +22,13 @@
         @test jlso[:b] == "hello"
         @test haskey(jlso.manifest, "BSON")
     end
+
+    @testset "no-arg constructor" begin
+        jlso = JLSOFile()
+        @test jlso isa JLSOFile
+        @test isempty(jlso.objects)
+        @test haskey(jlso.manifest, "BSON")
+    end
 end
 
 @testset "unknown format" begin

--- a/test/JLSOFile.jl
+++ b/test/JLSOFile.jl
@@ -65,7 +65,7 @@ end
 
 @testset "keys/haskey" begin
     jlso = JLSOFile(:string => datas[:String])
-    @test collect(keys(jlso1)) == [:string]
+    @test collect(keys(jlso)) == [:string]
     @test haskey(jlso, :string)
     @test !haskey(jlso, :other)
 end

--- a/test/JLSOFile.jl
+++ b/test/JLSOFile.jl
@@ -55,3 +55,27 @@ end
         @test Pkg.TOML.parsefile(joinpath(d, "Manifest.toml")) == jlso.manifest
     end
 end
+
+@testset "keys/haskey" begin
+    jlso = JLSOFile(:string => datas[:String])
+    @test collect(keys(jlso1)) == [:string]
+    @test haskey(jlso, :string)
+    @test !haskey(jlso, :other)
+end
+
+@testset "get/get!" begin
+    v = datas[:String]
+    jlso = JLSOFile(:str => v)
+    @test get(jlso, :str, "fail") == v
+    @test get!(jlso, :str, "fail") == v
+
+    @test get(jlso, :other, v) == v
+    @test !haskey(jlso, :other)
+
+    @test get!(jlso, :other, v) == v
+    @test jlso[:other] == v
+
+    # key must be a Symbol
+    @test get(jlso, "str", 999) == 999
+    @test_throws MethodError get!(jlso, "str", 999)
+end


### PR DESCRIPTION
- adds `keys`, `haskey`, `get` and `get!` for `JLSOFile` (but not `iterate` as i didn't have a use-cae for it); closes #107
- fixes `JLSOFile()` to return a `JLSOFile`, whereas on `master` it errrors:
    ```julia
    julia> JLSOFile()
  ERROR: MethodError: no method matching JLSOFile(::Dict{Union{}, Union{}}; version=v"4.0.0", julia=v"1.6.0", format=:julia_serialize, compression=:gzip, image="")
  Closest candidates are:
    JLSOFile(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) at /Users/nick/repos/JLSO.jl/src/JLSOFile.jl:2 got unsupported keyword arguments "version", "julia", "format", "compression", "image"
    JLSOFile(; version, julia, format, compression, image, kwargs...) at /Users/nick/repos/JLSO.jl/src/JLSOFile.jl:70
    JLSOFile(::Pair{Symbol, B} where B...; kwargs...) at /Users/nick/repos/JLSO.jl/src/JLSOFile.jl:89
    ...
  Stacktrace:
   [1] JLSOFile(; version::VersionNumber, julia::VersionNumber, format::Symbol, compression::Symbol, image::String, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
     @ JLSO ~/repos/JLSO.jl/src/JLSOFile.jl:78
   [2] JLSOFile()
     @ JLSO ~/repos/JLSO.jl/src/JLSOFile.jl:78
   [3] top-level scope
     @ REPL[2]:1
   ```
- adds a `save(io, ::JLSOFile)` method

Together, this allows users to write code like
```julia
jlso = isfile(filename) ? read(filename, JLSOFile) : JLSOFile()
get!(jlso, :qux) do
    make_qux()
end
JLSO.save(filename, jlso)
```
or
```julia
if isfile(filename) 
    jlso = read(filename, JLSOFile)
    haskey(jlso, :qux) && return jlso[:qux]
else
    jlso = JLSOFile()    
end
jlso[:qux] = make_qux()
JLSO.save(filename, jlso)
```

The main advantage is this allows working with a `JLSOFile` similar to working with the Dict that would be returned by `JLSO.load(filename)`, but with `JLSOFile` lazily deserialising (unlike `load`)