### PR TITLE
Stop using Memento

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,13 +2,12 @@ name = "JLSO"
 uuid = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 license = "MIT"
 authors = ["Invenia Technical Computing Corperation"]
-version = "2.6.0"
+version = "2.7.0"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
-Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
@@ -16,8 +15,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 BSON = "0.2.4, 0.3"
 CodecZlib = "0.6, 0.7"
 FilePathsBase = "0.7, 0.8, 0.9"
-Memento = "0.10, 0.11, 0.12, 0.13, 1"
-TimeZones = "0.9, 0.10, 0.11, 1"
+TimeZones = "0.9, 0.10, 0.11, ~1.0, ~1.1, ~1.2, ~1.3, ~1.4, ~1.5"
 julia = "0.7, 1.0"
 
 [extras]

--- a/src/JLSO.jl
+++ b/src/JLSO.jl
@@ -38,7 +38,6 @@ module JLSO
 using BSON
 using CodecZlib
 using FilePathsBase: AbstractPath
-using Memento
 using Pkg: Pkg
 using Pkg.Types: semver_spec
 using Serialization
@@ -59,8 +58,6 @@ export JLSOFile
 const READABLE_VERSIONS = semver_spec("1, 2, 3, 4")
 const WRITEABLE_VERSIONS = semver_spec("3, 4")
 
-const LOGGER = getlogger(@__MODULE__)
-__init__() = Memento.register(LOGGER)
 
 include("JLSOFile.jl")
 include("upgrade.jl")

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -82,7 +82,7 @@ function Base.read(io::IO, ::Type{JLSOFile})
             )
         )
     catch e
-        warn(LOGGER, e)
+        @warn exception=e
         Dict("raw" => d["metadata"]["manifest"])
     end
 

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,10 +1,7 @@
 function _versioncheck(version::VersionNumber, valid_versions)
     supported = version ∈ valid_versions
-    supported || error(LOGGER, ArgumentError(
-        string(
-            "Unsupported version ($version). ",
-            "Expected a value between ($valid_versions)."
-        )
+    supported || throw(ArgumentError(
+        "Unsupported version ($version). Expected a value between ($valid_versions)."
     ))
 end
 

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -53,7 +53,7 @@ function getindex(jlso::JLSOFile, name::Symbol)
         decompressing_buffer = decompress(jlso.compression, buffer)
         return deserialize(jlso.format, decompressing_buffer)
     catch e
-        warn(LOGGER, e)
+        @warn exception=e
         return jlso.objects[name]
     end
 end

--- a/src/upgrade.jl
+++ b/src/upgrade.jl
@@ -16,13 +16,13 @@ upgrade step. Won't be needed once the v2 file format is dropped.
     The project generated is accurate, except for duplicated names (no UUID) and custom branchs.
 """
 function upgrade(src, dest)
-    info(LOGGER, "Upgrading $src -> $dest")
+    @info "Upgrading" src dest
     jlso = open(io -> read(io, JLSOFile), src)
     write(dest, jlso)
 end
 
 function upgrade(src, dest, project, manifest)
-    info(LOGGER, "Upgrading $src -> $dest")
+    @info "Upgrading" src dest
     parsed = BSON.load(string(src))
     haskey(parsed["metadata"], "pkgs") && empty!(parsed["metadata"]["pkgs"])
     d = upgrade_jlso(parsed)
@@ -81,7 +81,7 @@ version_number(x::String) = VersionNumber(x)
 
 # Metadata changes to upgrade file from v1 to v2
 function upgrade_jlso(raw_dict::AbstractDict, ::Val{1})
-    info(LOGGER, "Upgrading JLSO format from v1 to v2")
+    @info "Upgrading JLSO format from v1 to v2"
     metadata = copy(raw_dict["metadata"])
     version = version_number(metadata["version"])
     @assert version ∈ semver_spec("1")
@@ -98,7 +98,7 @@ end
 
 # Metadata changes to upgrade from v2 to v3
 function upgrade_jlso(raw_dict::AbstractDict, ::Val{2})
-    info(LOGGER, "Upgrading JLSO format from v2 to v3")
+    @info "Upgrading JLSO format from v2 to v3"
     metadata = copy(raw_dict["metadata"])
     version = version_number(metadata["version"])
     @assert version ∈ semver_spec("2")
@@ -154,10 +154,12 @@ function _upgrade_env(pkgs::Dict{String, VersionNumber})
             catch e
                 # Warn about failure and fallback to simply trying to install the pacakges
                 # without version constraints.
-                warn(LOGGER) do
+                @warn(
                     "Failed to construct an environment with the provide package version " *
-                    "($pkgs): $e.\n Falling back to simply adding the packages."
-                end
+                    "\nFalling back to simply adding the packages.",
+                    pkgs,
+                    exception=e
+                )
                 Pkg.add([Pkg.PackageSpec(; name=key) for (key, value) in pkgs])
             end
 

--- a/test/JLSOFile.jl
+++ b/test/JLSOFile.jl
@@ -32,13 +32,8 @@
 end
 
 @testset "unknown format" begin
-    @test_throws(
-        LOGGER,
-        MethodError,
-        JLSOFile("String" => "Hello World!", format=:unknown)
-    )
+    @test_throws MethodError JLSOFile("String" => "Hello World!", format=:unknown)
 end
-
 @testset "show" begin
     jlso = JLSOFile(:string => datas[:String])
     expected = string(

--- a/test/backwards_compat.jl
+++ b/test/backwards_compat.jl
@@ -61,7 +61,7 @@
         @testset "$fn" for fn in readdir(dir)
             if Int === Int32 && occursin("_serialize", fn)
                 # Julia 64-bit serializations won't load on 32-bit systems
-                @test_warn(JLSO.LOGGER, r"MethodError*", JLSO.load(joinpath(dir, fn)))
+                @test_logs (:warn, "MethodError") JLSO.load(joinpath(dir, fn))
             else
                 jlso_data = @suppress_out JLSO.load(joinpath(dir, fn))
                 @test jlso_data == datas
@@ -81,7 +81,7 @@
 
                     if Int === Int32 && occursin("_serialize", fn)
                         # Julia 64-bit serializations won't load on 32-bit systems
-                        @test_warn(JLSO.LOGGER, r"MethodError*", JLSO.load(dest))
+                        @test_logs (:warn, "MethodError") JLSO.load(dest)
                     else
                         jlso_data = JLSO.load(dest)
                         @test jlso_data == datas

--- a/test/file_io.jl
+++ b/test/file_io.jl
@@ -42,12 +42,7 @@ end
 
         # Test failing to deserialize data because of incompatible julia versions
         # will return the raw bytes
-        result = if VERSION < v"1.2"
-            @test_warn(LOGGER, r"MethodError*", jlso[:data])
-        else
-            @test_warn(LOGGER, r"TypeError*", jlso[:data])
-        end
-
+        result = @test_logs (:warn,) jlso[:data]
         @test result == hw_5
 
         # TODO: Test that BSON works across julia versions using external files?
@@ -100,7 +95,7 @@ end
 
                 # Test failing to deserailize data because of missing modules will
                 # still return the raw bytes
-                result = @test_warn(LOGGER, r"KeyError*", jlso[:data])
+                result = @test_logs (:warn,) jlso[:data]
                 @test result == bytes
             end
 
@@ -137,7 +132,7 @@ end
 
                 # Test failing to deserailize data because of missing modules will
                 # still return the raw bytes
-                result = @test_warn(LOGGER, r"UndefVarError*", jlso[:data])
+                result = @test_logs (:warn,) jlso[:data]
 
                 @test result == bytes
             end
@@ -165,7 +160,6 @@ end
     end
     @testset "keys are not Symbols" begin
         @test_throws(
-            getlogger(JLSO),
             MethodError,
             JLSO.save("breakfast.jlso", "food" => "☕️🥓🍳", "time" => Time(9, 0)),
         )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ using Distributed
 using Documenter
 using FilePathsBase: SystemPath
 using InteractiveUtils
-using Memento
 using Pkg
 using Random
 using Serialization
@@ -12,7 +11,7 @@ using Suppressor
 using Test
 
 using JLSO
-using JLSO: JLSOFile, LOGGER, upgrade_jlso
+using JLSO: JLSOFile, upgrade_jlso
 
 # To test different types from common external packages
 using DataFrames


### PR DESCRIPTION
Closes #114 which will make dealing with data that was saves with different version of TimeZones.jl better.

Will also avoid other TimeZones related suffering hit by JLSO uses (cc @ablaom) like: 
 - slow load times
 - build-time cache breaking (I think those are all fixed now though)
 
`Test.@test_logs` is more annoying to work with than `Memento.@test_warn` see https://github.com/JuliaLang/julia/issues/43016.
This because `@warn exception=e` doesn't convert `e` to  a string as part of message so `@test_logs` doesn't accept a regex to apply to it.
Because of that we only test if a warning was given rather than what it says.


The change to the package code (rather than the test code) is pretty minimal

This PR should only be merged if @rofinn  is convinced.