### PR TITLE
Adds check for version number when running bson manifest tests

### DIFF
--- a/test/JLSOFile.jl
+++ b/test/JLSOFile.jl
@@ -20,14 +20,22 @@
     @testset "kwarg constructor" begin
         jlso = JLSOFile(; a=collect(1:10), b="hello")
         @test jlso[:b] == "hello"
-        @test haskey(jlso.manifest, "BSON")
+        if VERSION < v"1.7"
+            @test haskey(jlso.manifest, "BSON")
+        else
+            @test haskey(jlso.manifest["deps"], "BSON")
+        end
     end
 
     @testset "no-arg constructor" begin
         jlso = JLSOFile()
         @test jlso isa JLSOFile
         @test isempty(jlso.objects)
-        @test haskey(jlso.manifest, "BSON")
+        if VERSION < v"1.7"
+            @test haskey(jlso.manifest, "BSON")
+        else
+            @test haskey(jlso.manifest["deps"], "BSON")
+        end
     end
 end
 


### PR DESCRIPTION
These tests were failing, as the formatting for the manifest changes between julia version `1.6` and `1.7`.

For versions before `1.7`, we can just check if the JLSO `manifest` has the `BSON` key in it.

For versions equal to `1.7`, we have to check the `deps` field within the `manifest` for the `BSON` key.

These changes will fix this issue: #118 